### PR TITLE
fix: Lighthouse issue

### DIFF
--- a/components/common/ImageBySize/index.tsx
+++ b/components/common/ImageBySize/index.tsx
@@ -36,8 +36,8 @@ const ImageBySize = ({ images }: Props) => {
   }, [windowWidth])
 
   return (
-    src !== '' && (
-      <picture className={styles.picture}>
+    <picture className={styles.picture}>
+      {src !== '' && (
         <Image
           src={src}
           width={imgWidth}
@@ -48,8 +48,8 @@ const ImageBySize = ({ images }: Props) => {
           quality={100}
           priority
         />
-      </picture>
-    )
+      )}
+    </picture>
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio-ui",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Lighthouse issue:
These are the largest layout shifts observed on the page. Each table item represents a single layout shift, and shows the element that shifted the most. Below each item are possible root causes that led to the layout shift. Some of these layout shifts may not be included in the CLS metric value due to windowing. 